### PR TITLE
Revert "Derive Copy for Game"

### DIFF
--- a/onitama/src/bot.rs
+++ b/onitama/src/bot.rs
@@ -5,19 +5,16 @@ pub fn get_move(g: &Game) -> Move {
     moves.pop().unwrap()
 }
 
-pub fn perft(g: Game, depth: u64) -> u64 {
+pub fn perft(g: &Game, depth: u64) -> u64 {
     if depth == 0 || !g.in_progress {
         1
     } else {
         let moves = g.gen_moves();
-        moves
-            .iter()
-            .map(|m| {
-                let mut new_g = g;
-                new_g.take_turn(m);
-                perft(new_g, depth - 1)
-            })
-            .sum()
+        moves.iter().map(|m| {
+            let mut new_g = g.clone();
+            new_g.take_turn(m);
+            perft(&new_g, depth - 1)
+        }).sum()
     }
 }
 
@@ -38,27 +35,26 @@ mod tests {
     #[bench]
     fn bench_perft_3(b: &mut Bencher) {
         let game = test::black_box(Game::from_cards(Vec::from(CARDS)));
-        b.iter(|| perft(game, 3));
+        b.iter(|| perft(&game, 3));
     }
-
     #[bench]
     fn bench_perft_4(b: &mut Bencher) {
         let game = test::black_box(Game::from_cards(Vec::from(CARDS)));
-        b.iter(|| perft(game, 4));
+        b.iter(|| perft(&game, 4));
     }
     #[bench]
     fn bench_perft_5(b: &mut Bencher) {
         let game = test::black_box(Game::from_cards(Vec::from(CARDS)));
-        b.iter(|| perft(game, 5));
+        b.iter(|| perft(&game, 5));
     }
     #[bench]
     fn bench_perft_6(b: &mut Bencher) {
         let game = test::black_box(Game::from_cards(Vec::from(CARDS)));
-        b.iter(|| perft(game, 6));
+        b.iter(|| perft(&game, 6));
     }
     // #[bench]
     // fn bench_perft_7(b: &mut Bencher) {
     //     let game = test::black_box(Game::from_cards(Vec::from(CARDS)));
-    //     b.iter(|| perft(game, 7));
+    //     b.iter(|| perft(&game, 7));
     // }
 }

--- a/onitama/src/game.rs
+++ b/onitama/src/game.rs
@@ -14,7 +14,7 @@ pub struct Move {
     pub used_left_card: bool,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Game {
     white: Bitmap<U25>,
     black: Bitmap<U25>,
@@ -131,6 +131,7 @@ impl Game {
         while let Some(from_pos) = pieces.first_index() {
             pieces.set(from_pos, false);
             let mut left_shifted = shift_bitmap(&left, from_pos) & !my_pieces;
+
             while let Some(to_pos) = left_shifted.first_index() {
                 left_shifted.set(to_pos, false);
                 moves.push(Move {
@@ -282,20 +283,5 @@ mod tests {
         let game = test::black_box(Game::from_cards(cards));
 
         b.iter(|| game.gen_moves());
-    }
-
-    #[bench]
-    fn bench_take_turn(b: &mut Bencher) {
-        let cards = vec![
-            Card::Ox,
-            Card::Boar,
-            Card::Horse,
-            Card::Elephant,
-            Card::Crab,
-        ];
-        let mut game = test::black_box(Game::from_cards(cards));
-        let m = test::black_box(game.gen_moves().pop().unwrap());
-
-        b.iter(|| game.take_turn(&m));
     }
 }


### PR DESCRIPTION
Reverts ViliamVadocz/Autoplay#6

Turns out it's actually slower on my PC

```
with Copy
test bot::tests::bench_perft_3          ... bench:      25,891 ns/iter (+/- 4,057)
test bot::tests::bench_perft_4          ... bench:     386,668 ns/iter (+/- 11,944)
test bot::tests::bench_perft_5          ... bench:   6,367,350 ns/iter (+/- 106,756)
test bot::tests::bench_perft_6          ... bench: 103,793,770 ns/iter (+/- 5,284,851)

without Copy
test bot::tests::bench_perft_3          ... bench:      18,899 ns/iter (+/- 1,643)
test bot::tests::bench_perft_4          ... bench:     281,018 ns/iter (+/- 22,018)
test bot::tests::bench_perft_5          ... bench:   4,592,600 ns/iter (+/- 74,137)
test bot::tests::bench_perft_6          ... bench:  77,657,830 ns/iter (+/- 9,824,931)
```